### PR TITLE
[Fix] Fix the error KeyError: 'data_time'

### DIFF
--- a/projects/mmdet3d_plugin/apis/mmdet_train.py
+++ b/projects/mmdet3d_plugin/apis/mmdet_train.py
@@ -194,7 +194,7 @@ def custom_train_detector(
             time.ctime().replace(" ", "_").replace(":", "_"),
         )
         eval_hook = CustomDistEvalHook if distributed else EvalHook
-        runner.register_hook(eval_hook(val_dataloader, **eval_cfg))
+        runner.register_hook(eval_hook(val_dataloader, **eval_cfg), priority='LOW')
 
     # user-defined hooks
     if cfg.get("custom_hooks", None):


### PR DESCRIPTION
##  Issue number 
#4 closed

## reference
https://github.com/open-mmlab/mmsegmentation/pull/766/commits/1ef16866288d62c37e934130335a701acf7e3fa5

## chaged code
`projects/mmdet3d_plugin/apis/mmdet_train.py`

original code in line 197
```
        runner.register_hook(eval_hook(val_dataloader, **eval_cfg))
```

changed code in line 197
```
        runner.register_hook(eval_hook(val_dataloader, **eval_cfg), priority='LOW')
```

## result

The code is now working properly! Now the error logs that were in the issue are gone